### PR TITLE
track jobid in w&b

### DIFF
--- a/dolomite_engine/utils/tracking.py
+++ b/dolomite_engine/utils/tracking.py
@@ -12,6 +12,9 @@ if is_aim_available():
 if is_wandb_available():
     import wandb
 
+#track the LSF/Slurm job in W&B per run - bobcalio
+import os
+job = None if int(os.getenv("JOB_ID",0))==0 else int(os.getenv("JOB_ID"))
 
 class ProgressBar:
     """progress bar for training or validation"""
@@ -76,6 +79,10 @@ class ExperimentsTracker:
             # this is for a custom step, we can't use the wandb step
             # since it doesn't allow time travel to the past
             wandb.define_metric("iteration", hidden=True)
+            #track the LSF/Slurm job in W&B per run - bobcalio
+            if job is not None:
+                wandb.define_metric("job", step_metric="iteration", hidden=True, step_sync=True)
+
             wandb.define_metric("train/*", step_metric="iteration", step_sync=True)
             wandb.define_metric("val/*", step_metric="iteration", step_sync=True)
         elif experiments_tracker_name is not None:
@@ -131,6 +138,9 @@ class ExperimentsTracker:
                 # this is for a custom step, we can't use the wandb step
                 # since it doesn't allow time travel to the past
                 values["iteration"] = step
+                #track the LSF/Slurm job in W&B per run - bobcalio 
+                if job is not None:
+                    values["job"]= job
                 wandb.log(values)
             else:
                 raise ValueError(f"unexpected experiments_tracker ({self.experiments_tracker_name})")

--- a/dolomite_engine/utils/tracking.py
+++ b/dolomite_engine/utils/tracking.py
@@ -1,3 +1,5 @@
+import os
+
 from tqdm import tqdm
 
 from ..enums import ExperimentsTrackerName
@@ -12,9 +14,10 @@ if is_aim_available():
 if is_wandb_available():
     import wandb
 
-#track the LSF/Slurm job in W&B per run - bobcalio
-import os
-job = None if int(os.getenv("JOB_ID",0))==0 else int(os.getenv("JOB_ID"))
+
+# to track the LSF/Slurm job in W&B per run - bobcalio
+_JOB_ID = None if int(os.getenv("JOB_ID", -1)) == -1 else int(os.getenv("JOB_ID"))
+
 
 class ProgressBar:
     """progress bar for training or validation"""
@@ -79,8 +82,8 @@ class ExperimentsTracker:
             # this is for a custom step, we can't use the wandb step
             # since it doesn't allow time travel to the past
             wandb.define_metric("iteration", hidden=True)
-            #track the LSF/Slurm job in W&B per run - bobcalio
-            if job is not None:
+            # track the LSF/Slurm job in W&B per run - bobcalio
+            if _JOB_ID is not None:
                 wandb.define_metric("job", step_metric="iteration", hidden=True, step_sync=True)
 
             wandb.define_metric("train/*", step_metric="iteration", step_sync=True)
@@ -138,9 +141,9 @@ class ExperimentsTracker:
                 # this is for a custom step, we can't use the wandb step
                 # since it doesn't allow time travel to the past
                 values["iteration"] = step
-                #track the LSF/Slurm job in W&B per run - bobcalio 
-                if job is not None:
-                    values["job"]= job
+                # track the LSF/Slurm job in W&B per run - bobcalio
+                if _JOB_ID is not None:
+                    values["job"] = _JOB_ID
                 wandb.log(values)
             else:
                 raise ValueError(f"unexpected experiments_tracker ({self.experiments_tracker_name})")

--- a/scripts/blue-vela/pretrain.sh
+++ b/scripts/blue-vela/pretrain.sh
@@ -58,6 +58,9 @@ NNODES=$(echo ${LSB_MCPU_HOSTS} | tr ' ' '\n' | sed 'n; d' | wc -w)
 GPUS_PER_NODE=$(echo $CUDA_VISIBLE_DEVICES | tr ',' '\n' | wc -w)
 NODE_RANK=$(($(echo ${LSB_MCPU_HOSTS} | tr ' ' '\n' | sed 'n; d' | grep -n -m1 $(echo $HOSTNAME | cut -d'.' -f1) | cut -d':' -f1)-1))
 
+#track the LSF/Slurm job in W&B per run - bobcalio
+export JOB_ID=$LSB_JOBID 
+
 TOKENIZERS_PARALLELISM=false \
 torchrun --nnodes=$NNODES \
     --node_rank=$NODE_RANK \


### PR DESCRIPTION
This PR will add the LSF (or slurm) **jobid**  as a hidden metric in Weights & Biases.  This can be useful in long running jobs to track restarts, duration and other metrics by run and jobid.  

We can also use jobid to join the Model performance data with all compute system performance data  collected by node and GPU outside of w&b.